### PR TITLE
Fix case object branch transition deprecation.

### DIFF
--- a/dbus/private/types.nim
+++ b/dbus/private/types.nim
@@ -48,31 +48,21 @@ type DbusType* = ref object
     discard
 
 converter fromScalar*(ch: DbusTypeChar): DbusType =
-  new(result)
   assert ch notin dbusContainerTypes
-  result.kind = ch
+  DbusType(kind: ch)
 
 proc initArrayType*(itemType: DbusType): DbusType =
-  new(result)
-  result.kind = dtArray
-  result.itemType = itemType
+  DbusType(kind: dtArray, itemType: itemType)
 
 proc initDictEntryType*(keyType: DbusType, valueType: DbusType): DbusType =
   doAssert keyType.kind in dbusContainerTypes
-  new(result)
-  result.kind = dtDictEntry
-  result.keyType = keyType
-  result.valueType = valueType
+  DbusType(kind: dtDictEntry, keyType: keyType, valueType: valueType)
 
 proc initStructType*(itemTypes: seq[DbusType]): DbusType =
-  new(result)
-  result.kind = dtStruct
-  result.itemTypes = itemTypes
+  DbusType(kind: dtStruct, itemTypes: itemTypes)
 
 proc initVariantType*(variantType: DbusType): DbusType =
-  new(result)
-  result.kind = dtVariant
-  result.variantType = variantType
+  DbusType(kind: dtVariant, variantType: variantType)
 
 proc parseDbusFragment(signature: string): tuple[kind: DbusType, rest: string] =
   case signature[0]:

--- a/dbus/private/value.nim
+++ b/dbus/private/value.nim
@@ -81,105 +81,76 @@ proc getString(val: DbusValue): var string =
       raise newException(ValueError, "value is not string")
 
 proc createStringDbusValue(kind: DbusTypeChar, val: string): DbusValue =
-  new(result)
-  result.kind = kind
-  getString(result) = val
+  case kind
+  of dtString:
+    result = DbusValue(kind: kind, stringValue: val)
+  of dtSignature:
+    result = DbusValue(kind: kind, signatureValue: val.Signature)
+  of dtObjectPath:
+    result = DbusValue(kind: kind, objectPathValue: val.ObjectPath)
+  else:
+    raise newException(ValueError, "value is not string")
 
 proc createScalarDbusValue(kind: DbusTypeChar): tuple[value: DbusValue, scalarPtr: pointer] =
-  new(result.value)
-  result.value.kind = kind
-  result.scalarPtr = getPrimitive(result.value)
+  var value = DBusValue(kind: kind)
+  (value, getPrimitive(value))
 
 proc createDictEntryDbusValue(key, val: DbusValue): DbusValue =
-  new(result)
-  result.kind = dtDictEntry
-  result.dictKey = key
-  result.dictValue = val
+  DbusValue(kind: dtDictEntry, dictKey: key, dictValue: val)
 
 proc asDbusValue*(val: bool): DbusValue =
-  new(result)
-  result.kind = dtBool
-  result.boolValue = val
+  DbusValue(kind: dtBool, boolValue: val)
 
 proc asDbusValue*(val: float64): DbusValue =
-  new(result)
-  result.kind = dtDouble
-  result.doubleValue = val
+  DbusValue(kind: dtDouble, doubleValue: val)
 
 proc asDbusValue*(val: int16): DbusValue =
-  new(result)
-  result.kind = dtInt16
-  result.int16Value = val
+  DbusValue(kind: dtInt16, int16Value: val)
 
 proc asDbusValue*(val: int32): DbusValue =
-  new(result)
-  result.kind = dtInt32
-  result.int32Value = val
+  DbusValue(kind: dtInt32, int32Value: val)
 
 proc asDbusValue*(val: int64): DbusValue =
-  new(result)
-  result.kind = dtInt64
-  result.int64Value = val
+  DbusValue(kind: dtInt64, int64Value: val)
 
 proc asDbusValue*(val: uint16): DbusValue =
-  new(result)
-  result.kind = dtUint16
-  result.uint16Value = val
+  DbusValue(kind: dtUint16, uint16Value: val)
 
 proc asDbusValue*(val: uint32): DbusValue =
-  new(result)
-  result.kind = dtUint32
-  result.uint32Value = val
+  DbusValue(kind: dtUint32, uint32Value: val)
 
 proc asDbusValue*(val: uint64): DbusValue =
-  new(result)
-  result.kind = dtUint64
-  result.uint64Value = val
+  DbusValue(kind: dtUint64, uint64Value: val)
 
 proc asDbusValue*(val: uint8): DbusValue =
-  new(result)
-  result.kind = dtByte
-  result.byteValue = val
+  DbusValue(kind: dtByte, byteValue: val)
 
 proc asDbusValue*(val: string): DbusValue =
-  new(result)
-  result.kind = dtString
-  result.stringValue = val
+  DbusValue(kind: dtString, stringValue: val)
 
 proc asDbusValue*(val: ObjectPath): DbusValue =
-  new(result)
-  result.kind = dtString
-  result.objectPathValue = val
+  DbusValue(kind: dtObjectPath, objectPathValue: val)
 
 proc asDbusValue*(val: Signature): DbusValue =
-  new(result)
-  result.kind = dtSignature
-  result.signatureValue = val
+  DbusValue(kind: dtSignature, signatureValue: val)
 
 proc asDbusValue*[T](val: seq[T]): DbusValue =
-  new(result)
-  result.kind = dtArray
-  result.arrayValue = @[]
-  result.arrayValueType = getDbusType(T)
+  result = DbusValue(kind: dtArray, arrayValueType: getDbusType(T))
   for x in val:
     result.arrayValue.add x.asDbusValue
 
 proc asDbusValue*[K, V](val: Table[K, V]): DbusValue =
-  new(result)
-  result.kind = dtArray
-  result.arrayValue = @[]
-  result.arrayValueType = DbusType(kind: dtDictEntry,
-                                   keyType: getAnyDbusType(K),
-                                   valueType: getAnyDbusType(V))
+  result = DbusValue(kind: dtArray,
+                     arrayValueType: DbusType(kind: dtDictEntry,
+                                              keyType: getAnyDbusType(K),
+                                              valueType: getAnyDbusType(V)))
   for k, v in val:
     result.arrayValue.add(
       createDictEntryDbusValue(asDbusValue(k), asDbusValue(v)))
 
 proc asDbusValue*[T](val: Variant[T]): DbusValue =
-  new(result)
-  result.kind = dtVariant
-  result.variantType = getDbusType(T)
-  result.variantValue = asDbusValue(val.value)
+  DbusValue(kind: dtVariant, variantType: getDbusType(T),
+            variantValue: asDbusValue(val.value))
 
 proc asNative*(value: DbusValue, native: typedesc[bool]): bool =
   value.boolValue


### PR DESCRIPTION
Setting case branch is prohibited in 0.20, so case object need to be initialized explicitly. Incidentally this makes code more compact.

Version bump and tag would be greatly appreciated since this is breaking change fix.