### PR TITLE
unpack variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,39 @@
 libdbus binding for Nim
 
 
+## Testing
+
+The tests rely on the Python dbus service found in `tests/simple_service.py`.  Use one of the sections below to get an environment prepared to run the Python script, then run:
+
+```
+python tests/simple_service.py
+```
+
+Then run
+
+```
+nimble test
+```
+
+### Docker
+
+```
+docker run --rm -it --cap-add ipc_lock -v $(pwd):/code -w /code nimlang/nim /bin/bash
+```
+
+Within the running container:
+
+```
+apt-get update -q
+apt-get install -y dbus libdbus-1-dev python-gi python-dbus
+dbus-run-session -- bash
+```
+
+```
+python tests/simple_service.py &
+```
+
+
 ## Resources
 
 http://www.matthew.ath.cx/misc/dbus - libdbus tutorial

--- a/dbus.nimble
+++ b/dbus.nimble
@@ -9,3 +9,11 @@ license       = "MIT"
 
 requires "nim >= 0.19.0"
 requires "c2nim"
+
+
+task test, "Run integration tests":
+  exec "nim c --path:. -r dbus/private/tests/basic.nim"
+  exec "nim c --path:. -r dbus/private/tests/basic_use_wrapper.nim"
+  exec "nim c --path:. -r dbus/private/tests/basic_variant.nim"
+  exec "nim c --path:. -r dbus/private/tests/basic_wrapper.nim"
+  exec "nim c --path:. -r dbus/private/tests/notify.nim"

--- a/dbus/private/tests/.gitignore
+++ b/dbus/private/tests/.gitignore
@@ -1,6 +1,7 @@
 /basic
 /basic_wrapper
 /basic_use_wrapper
+/basic_variant
 /loop_test
 /listener
 /notify

--- a/dbus/private/tests/basic_variant.nim
+++ b/dbus/private/tests/basic_variant.nim
@@ -1,0 +1,23 @@
+import dbus
+
+let bus = getBus(dbus.DBUS_BUS_SESSION)
+var msg = makeCall("com.zielmicha.test",
+             ObjectPath("/com/zielmicha/test"),
+             "com.zielmicha.test",
+             "hello")
+
+msg.append(newVariant("hi"))
+
+let pending = bus.sendMessageWithReply(msg)
+let reply = pending.waitForReply()
+reply.raiseIfError()
+
+var it = reply.iterate
+let v = it.unpackCurrent(DbusValue)
+assert v.asNative(string) == "Hello, world!"
+it.advanceIter
+let val = it.unpackCurrent(DbusValue)
+assert val.kind == dtString
+assert val.asNative(string) == "hi"
+
+

--- a/dbus/private/value.nim
+++ b/dbus/private/value.nim
@@ -4,7 +4,7 @@ type
   FD* = cint
 
   DbusValue* = ref object
-    case kind: DbusTypeChar:
+    case kind*: DbusTypeChar:
       of dtArray:
         arrayValueType*: DbusType
         arrayValue*: seq[DbusValue]

--- a/tests/simple_service.py
+++ b/tests/simple_service.py
@@ -1,4 +1,4 @@
-from gi.repository import Gtk
+from gi.repository import GLib
 import dbus
 import dbus.service
 from dbus.mainloop.glib import DBusGMainLoop
@@ -19,4 +19,6 @@ class MyDBUSService(dbus.service.Object):
 
 DBusGMainLoop(set_as_default=True)
 myservice = MyDBUSService()
-Gtk.main()
+
+loop = GLib.MainLoop()
+loop.run()


### PR DESCRIPTION
This change includes the following:

- New feature: unpackCurrent can unpack simple Dbus Variants
- Added documentation for how to run the tests (it took a while to figure that out)
- Rely on `from gi.repository import GLib` instead of `Gtk` because I could never get the right dependencies installed