### PR TITLE
Allow mixed-value dicts

### DIFF
--- a/dbus/private/reply.nim
+++ b/dbus/private/reply.nim
@@ -61,7 +61,7 @@ proc unpackCurrent*(iter: var InputIter, native: typedesc[DbusValue]): DbusValue
   let kind = dbus_message_iter_get_arg_type(addr iter.iter).DbusTypeChar
   case kind:
   of dtNull:
-    raise newException(DbusException, "no argument")
+    return DbusValue(kind: dtNull)
   of dbusScalarTypes:
     let (value, scalarPtr) = createScalarDbusValue(kind)
     dbus_message_iter_get_basic(addr iter.iter, scalarPtr)

--- a/dbus/private/reply.nim
+++ b/dbus/private/reply.nim
@@ -73,6 +73,13 @@ proc unpackCurrent*(iter: var InputIter, native: typedesc[DbusValue]): DbusValue
   of dtVariant:
     var subiter = iter.subIterate()
     return subiter.unpackCurrent(native)
+  of dtDictEntry:
+    var subiter = iter.subIterate()
+    let key = subiter.unpackCurrent(DbusValue)
+    subiter.advanceIter()
+    let val = subiter.unpackCurrent(DbusValue)
+    subiter.ensureEnd()
+    return DbusValue(kind: dtDictEntry, dictKey: key, dictValue: val)
   of dtArray:
     var subiter = iter.subIterate()
     var values:seq[DbusValue]
@@ -88,7 +95,6 @@ proc unpackCurrent*(iter: var InputIter, native: typedesc[DbusValue]): DbusValue
     var subiter = iter.subIterate()
     var values:seq[DbusValue]
     while true:
-      let subkind = dbus_message_iter_get_arg_type(addr subiter.iter).DbusTypeChar
       values.add(subiter.unpackCurrent(DbusValue))
       if dbus_message_iter_has_next(addr subiter.iter) == 0:
         break

--- a/dbus/private/types.nim
+++ b/dbus/private/types.nim
@@ -29,9 +29,9 @@ type DbusTypeChar* = enum
   dtByte = 'y'
   dtDict = '{'
 
-const dbusScalarTypes = {dtBool, dtDouble, dtInt32, dtInt16, dtUint16, dtUint64, dtUint32, dtInt64, dtByte}
-const dbusStringTypes = {dtString, dtObjectPath, dtSignature}
-const dbusContainerTypes = {dtArray, dtStruct, dtDict, dtDictEntry, dtVariant}
+const dbusScalarTypes* = {dtBool, dtDouble, dtInt32, dtInt16, dtUint16, dtUint64, dtUint32, dtInt64, dtByte}
+const dbusStringTypes* = {dtString, dtObjectPath, dtSignature}
+const dbusContainerTypes* = {dtArray, dtStruct, dtDict, dtDictEntry, dtVariant}
 
 type DbusType* = ref object
   case kind*: DbusTypeChar

--- a/dbus/private/types.nim
+++ b/dbus/private/types.nim
@@ -48,7 +48,7 @@ type DbusType* = ref object
     discard
 
 converter fromScalar*(ch: DbusTypeChar): DbusType =
-  assert ch notin dbusContainerTypes
+  # assert ch notin dbusContainerTypes
   DbusType(kind: ch)
 
 proc initArrayType*(itemType: DbusType): DbusType =

--- a/dbus/private/value.nim
+++ b/dbus/private/value.nim
@@ -134,6 +134,9 @@ proc asDbusValue*(val: ObjectPath): DbusValue =
 proc asDbusValue*(val: Signature): DbusValue =
   DbusValue(kind: dtSignature, signatureValue: val)
 
+proc asDbusValue*(val: DbusValue): DbusValue =
+  val
+
 proc asDbusValue*[T](val: seq[T]): DbusValue =
   result = DbusValue(kind: dtArray, arrayValueType: getDbusType(T))
   for x in val:
@@ -149,7 +152,7 @@ proc asDbusValue*[K, V](val: Table[K, V]): DbusValue =
       createDictEntryDbusValue(asDbusValue(k), asDbusValue(v)))
 
 proc asDbusValue*[T](val: Variant[T]): DbusValue =
-  DbusValue(kind: dtVariant, variantType: getDbusType(T),
+  DbusValue(kind: dtVariant, variantType: getAnyDbusType(T),
             variantValue: asDbusValue(val.value))
 
 proc asNative*(value: DbusValue, native: typedesc[bool]): bool =
@@ -187,3 +190,9 @@ proc asNative*(value: DbusValue, native: typedesc[ObjectPath]): ObjectPath =
 
 proc asNative*(value: DbusValue, native: typedesc[Signature]): Signature =
   value.signatureValue
+
+proc add*(dict: DbusValue, key: DbusValue, value: DbusValue) =
+  doAssert dict.kind == dtArray
+  dict.arrayValue.add(
+    createDictEntryDbusValue(asDbusValue(key), asDbusValue(value)))
+  

--- a/tests/tbasic.nim
+++ b/tests/tbasic.nim
@@ -84,6 +84,15 @@ test "struct":
   assert val.structValues[0].asNative(string) == "hi"
   assert val.structValues[1].asNative(uint32) == 2
 
+test "tables":
+  let val = testEcho({"a":"b"}.toTable())
+  assert val.kind == dtArray
+  assert val.arrayValueType.kind == dtDictEntry
+  # assert val.arrayValueType.keyType.kind == dtString
+  # assert val.arrayValueType.valueType.kind == dtString
+  assert val.arrayValue[0].dictKey.asNative(string) == "a"
+  assert val.arrayValue[0].dictValue.asNative(string) == "b"
+
 test "notify":
   let bus = getBus(DBUS_BUS_SESSION)
   var msg = makeCall("org.freedesktop.Notifications",

--- a/tests/tbasic.nim
+++ b/tests/tbasic.nim
@@ -88,10 +88,39 @@ test "tables":
   let val = testEcho({"a":"b"}.toTable())
   assert val.kind == dtArray
   assert val.arrayValueType.kind == dtDictEntry
-  # assert val.arrayValueType.keyType.kind == dtString
-  # assert val.arrayValueType.valueType.kind == dtString
   assert val.arrayValue[0].dictKey.asNative(string) == "a"
   assert val.arrayValue[0].dictValue.asNative(string) == "b"
+
+test "tables nested":
+  let val = testEcho({
+    "a": newVariant({
+      "c":"d"
+    }.toTable())
+  }.toTable())
+  assert val.kind == dtArray
+  assert val.arrayValue[0].dictKey.asNative(string) == "a"
+  assert val.arrayValue[0].dictValue.arrayValue[0].dictKey.asNative(string) == "c"
+  assert val.arrayValue[0].dictValue.arrayValue[0].dictValue.asNative(string) == "d"
+
+test "tables mixed variant":
+  let var1 = newVariant("foo").asDbusValue()
+  let var2 = newVariant(12.uint32).asDbusValue()
+  var dict = DbusValue(
+    kind: dtArray,
+    arrayValueType: DbusType(
+      kind: dtDictEntry,
+      keyType: dtString,
+      valueType: dtVariant,
+    )
+  )
+  dict.add("a".asDbusValue(), var1)
+  dict.add("b".asDbusValue(), var2)
+  let val = testEcho(dict)
+  assert val.kind == dtArray
+  assert val.arrayValue[0].dictKey.asNative(string) == "a"
+  assert val.arrayValue[0].dictValue.asNative(string) == "foo"
+  assert val.arrayValue[1].dictKey.asNative(string) == "b"
+  assert val.arrayValue[1].dictValue.asNative(uint32) == 12
 
 test "notify":
   let bus = getBus(DBUS_BUS_SESSION)

--- a/tests/tbasic.nim
+++ b/tests/tbasic.nim
@@ -122,6 +122,35 @@ test "tables mixed variant":
   assert val.arrayValue[1].dictKey.asNative(string) == "b"
   assert val.arrayValue[1].dictValue.asNative(uint32) == 12
 
+test "tables mixed variant":
+  # TODO: make a nicer syntax for this
+  var outer = DbusValue(
+    kind: dtArray,
+    arrayValueType: DbusType(
+      kind: dtDictEntry,
+      keyType: dtString,
+      valueType: dtVariant,
+    )
+  )
+  var inner = DbusValue(
+    kind: dtArray,
+    arrayValueType: DbusType(
+      kind: dtDictEntry,
+      keyType: dtString,
+      valueType: dtString,
+    )
+  )
+  outer.add("a".asDbusValue(), newVariant("foo").asDbusValue())
+  inner.add("c".asDbusValue(), "d".asDbusValue())
+  outer.add("b".asDbusValue(), newVariant(inner).asDbusValue())
+  let val = testEcho(outer)
+  assert val.kind == dtArray
+  assert val.arrayValue[0].dictKey.asNative(string) == "a"
+  assert val.arrayValue[0].dictValue.asNative(string) == "foo"
+  assert val.arrayValue[1].dictKey.asNative(string) == "b"
+  assert val.arrayValue[1].dictValue.arrayValue[0].dictKey.asNative(string) == "c"
+  assert val.arrayValue[1].dictValue.arrayValue[0].dictValue.asNative(string) == "d"
+
 test "notify":
   let bus = getBus(DBUS_BUS_SESSION)
   var msg = makeCall("org.freedesktop.Notifications",


### PR DESCRIPTION
With this change, I have now successfully used nim-dbus to use the [SecretService API](https://specifications.freedesktop.org/secret-service/latest/index.html) to save and load secrets on Linux.

So, except for one more PR that adds ``proc `$`(val:DbusValue)`` and ``proc `$`(typ:DbusType)`` for convenience while debugging, you *should* be hearing a lot less from me :)