### PR TITLE
Remove GCed memory from MainLoop

### DIFF
--- a/dbus/loop.nim
+++ b/dbus/loop.nim
@@ -26,6 +26,7 @@ proc removeWatch(oldWatch: ptr DBusWatch, loopPtr: pointer) {.cdecl.} =
   for watch in loop.watches.mitems:
     if watch == oldWatch:
       watch = nil
+      break
   dec loop.watchesCount
 
 proc toggleWatch(watch: ptr DBusWatch, loopPtr: pointer) {.cdecl.} =


### PR DESCRIPTION
Since MainLoop is created with `create` the sequence stored within it
isn't visible to the GC. So when it runs it doesn't find the reference
to it and can therefore end up freeing it. This commit fixes #17 which
was caused by such a scenario (probably because the Firefox notification
included an icon which contains enough data to have triggered the GC).
This also means that MainLoop can now be free'd manually if the user
wishes to use `create` and `tick` without `runForever`.